### PR TITLE
Delegate with null pipe for incompatible value types

### DIFF
--- a/src/Modifiers/FormatterModifier.php
+++ b/src/Modifiers/FormatterModifier.php
@@ -40,8 +40,12 @@ final readonly class FormatterModifier implements Modifier
 
         $formatter = $this->tryToCreateFormatter($name, $arguments);
 
-        if ($formatter === null || !is_scalar($value)) {
+        if ($formatter === null) {
             return $this->nextModifier->modify($value, $pipe);
+        }
+
+        if (!is_scalar($value)) {
+            return $this->nextModifier->modify($value, null);
         }
 
         return $formatter->format((string) $value);

--- a/tests/Helper/TestingModifier.php
+++ b/tests/Helper/TestingModifier.php
@@ -17,12 +17,16 @@ use function sprintf;
 
 final class TestingModifier implements Modifier
 {
+    public string|null $lastPipe = null;
+
     public function __construct(private string|null $customResult = null)
     {
     }
 
     public function modify(mixed $value, string|null $pipe): string
     {
+        $this->lastPipe = $pipe;
+
         return $this->customResult ?? ($pipe ? sprintf('%s(%s)', $pipe, print_r($value, true)) : print_r($value, true));
     }
 }


### PR DESCRIPTION
Separate handling of invalid formatters from non-scalar values. When a formatter is recognized but the value type is incompatible, pass null to the next modifier instead of the original pipe. This prevents incorrectly suggesting the next modifier should retry with the same formatter.

Added tests using data providers to verify the distinction between pipe not being valid and modifier being unable to modify values.

Assisted-by: OpenCode (GLM-4.7)