### PR TITLE
Move FormatterModifier after TransModifier and ListModifier

### DIFF
--- a/src/PlaceholderFormatter.php
+++ b/src/PlaceholderFormatter.php
@@ -25,9 +25,9 @@ final readonly class PlaceholderFormatter implements Formatter
     /** @param array<string, mixed> $parameters */
     public function __construct(
         private array $parameters,
-        private Modifier $modifier = new FormatterModifier(
-            new TransModifier(
-                new ListModifier(new StringPassthroughModifier(new StringifyModifier())),
+        private Modifier $modifier = new TransModifier(
+            new ListModifier(
+                new FormatterModifier(new StringPassthroughModifier(new StringifyModifier())),
             ),
         ),
     ) {


### PR DESCRIPTION
Positioning FormatterModifier later in the chain allows TransModifier and ListModifier to handle their specific pipes first. Since FormatterModifier attempts to create a formatter for any pipe it encounters, this change avoids unnecessary formatter creation attempts for known modifiers like `|trans` and `|list`, improving performance.

Assisted-by: OpenCode (GLM-4.7)